### PR TITLE
Drop score, add Composition section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">An open protocol for algorithmic feeds.</p>
 
-CommonFeed is a JSON-over-HTTPS protocol for serving algorithmic feeds. Providers compute and rank content; consumers (servers, native clients, or web apps) query the provider and render the results. Requests carry no user identifiers.
+CommonFeed is a JSON-over-HTTPS protocol for algorithmic feeds. Providers compute and rank content; consumers (servers, native clients, or web apps) query one or more providers and assemble the feed they show users. Requests carry no user identifiers.
 
 ## Status
 

--- a/v0.1/links.md
+++ b/v0.1/links.md
@@ -22,7 +22,6 @@ Result items for `links` resources. Each item represents a link with preview met
 | `favicon` | ImageObject | No | Site favicon (see [ImageObject](posts.md#imageobject)) |
 | `postCount` | Integer | Yes | Total posts sharing this link in the time window |
 | `accountCount` | Integer | Yes | Unique authors sharing this link in the time window |
-| `score` | Float | No | Relevance score in `[0, 1]`, normalized by the provider; higher means more relevant |
 
 The link metadata fields (`url` through `publishedAt`) are the same shape as the [Link Object](posts.md#link-object) on post results. The Link Result adds usage statistics (`postCount`, `accountCount`, `score`).
 

--- a/v0.1/links.md
+++ b/v0.1/links.md
@@ -23,7 +23,7 @@ Result items for `links` resources. Each item represents a link with preview met
 | `postCount` | Integer | Yes | Total posts sharing this link in the time window |
 | `accountCount` | Integer | Yes | Unique authors sharing this link in the time window |
 
-The link metadata fields (`url` through `publishedAt`) are the same shape as the [Link Object](posts.md#link-object) on post results. The Link Result adds usage statistics (`postCount`, `accountCount`, `score`).
+The link metadata fields (`url` through `publishedAt`) are the same shape as the [Link Object](posts.md#link-object) on post results. The Link Result adds usage statistics (`postCount`, `accountCount`).
 
 <details>
 <summary>Example</summary>
@@ -68,8 +68,7 @@ The link metadata fields (`url` through `publishedAt`) are the same shape as the
   "language": "en",
   "publishedAt": "2026-02-27T10:00:00Z",
   "postCount": 42,
-  "accountCount": 15,
-  "score": 0.85
+  "accountCount": 15
 }
 ```
 

--- a/v0.1/lookups.md
+++ b/v0.1/lookups.md
@@ -110,7 +110,7 @@ Returns posts that quote the specified post.
 | `pagination.cursorExpiresAt` | String | No | ISO 8601 expiry time for the cursor |
 | `pagination.hasMore` | Boolean | Yes | Whether more results exist |
 
-There is no `algorithm` field; these endpoints use provider-default ordering. The `score` field is absent on result items since no algorithmic ranking was applied.
+There is no `algorithm` field; these endpoints use provider-default ordering.
 
 <details>
 <summary>Example</summary>

--- a/v0.1/overview.md
+++ b/v0.1/overview.md
@@ -65,6 +65,10 @@ Consumers MUST ignore unrecognized fields, object keys, and enumeration values. 
 
 Anonymity properties scale with the consumer's user base. Multi-user consumers hide individual users in the consumer's traffic; single-user consumers reveal one user's query patterns to the provider through network metadata, though the wire payload remains identifier-free.
 
+## Composition
+
+Consumers MAY query multiple providers and merge results into a single feed. The merging strategy is a consumer concern. The `identifiers` field on result items (see [Posts](posts.md#protocol-identifier-formats)) enables deduplication of items returned by more than one provider. Consumers SHOULD cache responses to limit fan-out load on providers.
+
 ## Versioning
 
 Two versions are independent:

--- a/v0.1/posts.md
+++ b/v0.1/posts.md
@@ -158,8 +158,7 @@ Because identifiers are protocol-canonical, consumers querying multiple provider
     "likes": 142,
     "reposts": 38,
     "replies": 12
-  },
-  "score": 0.904
+  }
 }
 ```
 
@@ -267,7 +266,6 @@ The parent PostItem follows the standard PostItem schema with the following cons
 - `id`: MAY be absent
 - `replyTo`: always absent (no recursive nesting; max depth is 1)
 - `quote`: always absent
-- `score`: always absent
 - `context`: always absent
 
 If the parent post is unavailable (deleted, not yet resolved), providers MUST omit `replyTo` entirely rather than serving partial data.
@@ -283,7 +281,6 @@ The quoted PostItem follows the standard PostItem schema with the following cons
 - `id`: MAY be absent
 - `quote`: always absent (no recursive nesting; max depth is 1)
 - `replyTo`: always absent
-- `score`: always absent
 - `context`: always absent
 
 If the quoted post is unavailable (deleted, not yet resolved), providers MUST omit `quote` entirely rather than serving partial data.

--- a/v0.1/posts.md
+++ b/v0.1/posts.md
@@ -25,7 +25,6 @@ Result items for `posts` resources. Each item represents a piece of content from
 | `quote` | PostItem | No | The quoted post, inline as a full PostItem (absent if not a quote post, see [Quoted Posts](#quoted-posts)) |
 | `tags` | Array | No | Hashtags used in the content (absent if none, see below) |
 | `emojis` | Array | No | Custom emojis used in the content (absent if none, see below) |
-| `score` | Float | No | Relevance score in `[0, 1]`, normalized by the provider; higher means more relevant |
 | `context` | String | No | Opaque per-item context token. When present, consumers SHOULD pass this value back to the provider with engagement signals for the item. Providers use this for feedback loops (e.g. closing the loop between recommendation and observed engagement). Consumers MUST NOT interpret, parse, or make decisions based on the contents of this field |
 
 Engagement counts are approximate and may be stale. Consumers SHOULD NOT treat them as authoritative.
@@ -41,6 +40,8 @@ Engagement counts are approximate and may be stale. Consumers SHOULD NOT treat t
 | `nostr` | `nostr:<64-char lowercase hex event ID>` | `nostr:<64-char lowercase hex pubkey>` |
 
 Providers MAY include identifiers from multiple protocols on the same item when content has been ingested via bridged copies (e.g. a Bluesky post bridged via Bridgy Fed will have both `atproto` and `activitypub` keys).
+
+Because identifiers are protocol-canonical, consumers querying multiple providers MAY use them to deduplicate items returned by more than one.
 
 <details>
 <summary>Example</summary>

--- a/v0.1/queries.md
+++ b/v0.1/queries.md
@@ -150,8 +150,7 @@ Response (see [Responses](responses.md) for envelope, [Posts](posts.md) for item
         "likes": 89,
         "reposts": 23,
         "replies": 7
-      },
-      "score": 0.847
+      }
     }
   ],
   "algorithm": "commonfeed-recommended-v1",

--- a/v0.1/tags.md
+++ b/v0.1/tags.md
@@ -12,8 +12,7 @@ Result items for `tags` resources. Each item represents a hashtag with usage sta
   "history": [
     { "day": "1709251200", "uses": 30, "accounts": 12 },
     { "day": "1709164800", "uses": 25, "accounts": 10 }
-  ],
-  "score": 0.92
+  ]
 }
 ```
 

--- a/v0.1/tags.md
+++ b/v0.1/tags.md
@@ -28,4 +28,3 @@ Result items for `tags` resources. Each item represents a hashtag with usage sta
 | `history[].day` | String | Yes | Unix timestamp of the start of the day (UTC), encoded as a string for compatibility with Mastodon's trends API |
 | `history[].uses` | Integer | Yes | Posts using this tag on that day |
 | `history[].accounts` | Integer | Yes | Unique authors on that day |
-| `score` | Float | No | Relevance score in `[0, 1]`, normalized by the provider; higher means more relevant |


### PR DESCRIPTION
Address #1 (composition / multi-provider feeds):

- Remove `score` from v0.1. Ranking transparency deserves proper design before we ship a half-measure.
- Add a short Composition note to `overview.md`: consumers may query multiple providers and merge results; recommend caching to limit fan-out load.
- Note in `posts.md` that `identifiers` enable cross-provider deduplication.
- Sharpen the README opening to reflect the multi-provider design.

Closes #1