### PR TITLE
Define embedding methods (ema0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Reference implementations:
 | [Tags](v0.1/tags.md) | Tag result items |
 | [Links](v0.1/links.md) | Link result items |
 | [Errors](v0.1/errors.md) | Error codes and rate limit headers |
+| [Embedding methods](guidelines/embeddings/) | Documented aggregation methods referenced by capability identifiers |
 
 ## Privacy
 

--- a/guidelines/embeddings/README.md
+++ b/guidelines/embeddings/README.md
@@ -1,0 +1,30 @@
+# Embedding Methods
+
+Discovery's `embedding.methods` array names the methods a provider accepts. Each entry has a method `name` (e.g. `ema0.1`) and, when the method depends on an external embedding model, a `model`. Entries MAY also carry a `params` object for method-specific tunables that the consumer must apply when computing the vector. The method fixes how per-event embeddings are aggregated into the user vector; the model (when present) fixes the embedding space; `params` carries any additional values required to reproduce the vector deterministically.
+
+The wire spec (vector layout, dimensionality, normalization, validation) lives in [Discovery](../../v0.1/discovery.md#embedding-capability) and [Queries](../../v0.1/queries.md#embedding). The per-method docs here cover what the wire spec deliberately leaves out: how the consumer turns user behavior into the vector that gets sent.
+
+## Identifier conventions
+
+Method identifiers SHOULD carry a version suffix (e.g. `ema0.1`). Aggregation rule changes that produce different vectors from the same behavior MUST bump the method version, since the identifier is the contract that lets two consumers reproduce the same vector.
+
+A method MAY require a model (in which case the capability entry MUST declare one) or be self-contained (no `model` field on the entry). The method document declares which.
+
+## What a method document covers
+
+Each method document SHOULD cover:
+
+- **Compatible models.** Which model identifiers this method is defined against, or that the method is self-contained.
+- **Encoder.** What gets encoded per event (text only, text plus metadata, etc.), or that the method does not use a per-event encoder.
+- **Aggregation rule.** The formula and any per-event-kind weights, with concrete numbers.
+- **Cold start.** What a consumer sends before the user has produced any signal.
+- **Negative signals.** How (or whether) hides, mutes, and similar are folded in.
+- **Rotation and perturbation.** Concrete recipe for the consumer-side privacy guidance in the wire spec.
+
+## Methods
+
+- [`ema0.1`](ema0.1.md): EMA over per-post content embeddings, per-event-kind learning rates.
+
+## Adding a new method
+
+The spec does not gate registration. A provider that wants to advertise a new method publishes its specification (anywhere stable) and uses the identifier in its capability. Methods of broad interest can be contributed as files in this directory through a pull request.

--- a/guidelines/embeddings/ema0.1.md
+++ b/guidelines/embeddings/ema0.1.md
@@ -14,12 +14,7 @@ Example capability entry:
   "model": "Qwen/Qwen3-Embedding-0.6B",
   "dims": 1024,
   "params": {
-    "alpha": {
-      "like": 0.05,
-      "repost": 0.075,
-      "reply": 0.15,
-      "bookmark": 0.10
-    }
+    "alpha": 0.05
   }
 }
 ```
@@ -28,15 +23,47 @@ Example capability entry:
 
 | Key | Type | Required | Description |
 |-----|------|----------|-------------|
-| `alpha` | Object | Yes | Per-event-kind EMA learning rates. Required keys: `like`, `repost`, `reply`, `bookmark`. Each value MUST be a number in `[0, 1]` |
+| `alpha` | Number | Yes | Base EMA learning rate. MUST be in `[0, 1]`. |
 
-`alpha[k]` is the weight given to a new event of kind `k` in the EMA update; `1 − alpha[k]` is the weight retained from prior state. Setting `alpha[k] = 0` causes events of that kind to have no effect on the user vector. Setting `alpha[k] = 1` causes events of that kind to replace prior state entirely.
+`alpha` is the provider-declared base decay rate. Each engagement event is scaled by a per-kind weight chosen by the consumer; the effective learning rate for a kind `k` is `α_eff[k] = clamp(alpha × weight[k], 0, 1)`. Setting `α_eff[k] = 0` causes events of kind `k` to have no effect on the user vector; setting `α_eff[k] = 1` causes them to replace prior state entirely.
 
-The provider advertises `alpha` in the capability entry's `params` object. Consumers MUST use exactly the values declared by the provider. Two providers advertising `ema0.1` with different `alpha` values will produce different vectors from the same behavior.
+Consumers MUST use the `alpha` value declared by the provider. Two providers advertising `ema0.1` with different `alpha` values will produce different decay characteristics from the same behavior; that is the provider's tuning.
+
+## Engagement scaling
+
+Engagement types and their relative weights are consumer-side concerns. A consumer applies whichever engagement primitives its host protocol surfaces, and SHOULD scale `alpha` per type so that stronger signals (typically those requiring more user effort or expressing more intent) drive larger updates than weaker ones.
+
+`ema0.1` does not enumerate engagement types. Different consumers run on different protocols (ActivityPub, AT Protocol, Nostr, etc.) with different engagement primitives; a consumer's engagement vocabulary is its own to define.
+
+The provider never observes individual engagement events. All events are applied consumer-side from the consumer's local state; the provider only sees the resulting unit vector.
+
+### Example weight set
+
+For a consumer exposing a Mastodon-style engagement vocabulary, a reasonable baseline:
+
+| Kind | Recommended weight | Notes |
+|------|---------------------|-------|
+| `like` | 0.5 | Low effort, noisy positive signal. |
+| `repost` | 1.0 | Public amplification. |
+| `reply` | 1.5 | Writing effort and topical commentary. |
+| `quote` | 2.0 | Public commentary with explicit reference to the source. |
+| `bookmark` | 2.5 | Private intent ("I want to revisit this"); no social-performance overlay. |
+
+With these weights and `alpha = 0.05`, effective alphas are:
+
+| Kind | `α_eff` |
+|------|---------|
+| `like` | 0.025 |
+| `repost` | 0.050 |
+| `reply` | 0.075 |
+| `quote` | 0.100 |
+| `bookmark` | 0.125 |
+
+Consumers SHOULD adapt these to their own engagement vocabulary and user base. The recommended values are guidance, not requirement.
 
 ## Encoder
 
-The consumer encodes each engaged post into a unit vector using the model declared in the capability entry. The text fed to the model is, in order, whatever of the following is present: author display name and handle, content warning, post title, post summary, post body, image alt text, hashtags. Fields that are absent are skipped. The exact template used by the reference implementation is at [`fediway/feeds/workers/orbit/templates/embedding.j2`](https://github.com/fediway/feeds/blob/main/workers/orbit/templates/embedding.j2).
+The consumer encodes each engaged post into a unit vector using the model declared in the capability entry. When an engagement event represents a response to another post (e.g., reply, quote), the engaged post is the post being responded to, not the post the user authored. The text fed to the model is, in order, whatever of the following is present: author display name and handle, content warning, post title, post summary, post body, image alt text, hashtags. Fields that are absent are skipped. The exact template used by the reference implementation is at [`fediway/feeds/workers/orbit/templates/embedding.j2`](https://github.com/fediway/feeds/blob/main/workers/orbit/templates/embedding.j2).
 
 The model's output is L2-normalized before aggregation.
 
@@ -69,10 +96,11 @@ Sections are separated by a single blank line; absent fields are skipped along w
 For each engagement event in chronological order:
 
 ```
-new = normalize(α[k] · post_embedding + (1 − α[k]) · current)
+α_eff[k] = clamp(alpha · weight[k], 0, 1)
+new = normalize(α_eff[k] · post_embedding + (1 − α_eff[k]) · current)
 ```
 
-where `current` is the user's vector before the event, `post_embedding` is the unit-normalized post embedding, `k` is the event kind, and `α[k]` is the value of `params.alpha[k]`. The result is L2-normalized after every step. The user vector sent in the request is the value of `current` after applying all events.
+where `current` is the user's vector before the event, `post_embedding` is the unit-normalized post embedding, `k` is the event kind, `alpha` is the provider-declared base rate from `params.alpha`, and `weight[k]` is the consumer-chosen per-kind weight. The result is L2-normalized after every step. The user vector sent in the request is the value of `current` after applying all events.
 
 ## Cold start
 

--- a/guidelines/embeddings/ema0.1.md
+++ b/guidelines/embeddings/ema0.1.md
@@ -1,0 +1,92 @@
+# Method: `ema0.1`
+
+EMA over per-post content embeddings with per-event-kind learning rates.
+
+## Compatible models
+
+Any embedding model that accepts text input (text-only or multimodal). The vector this method produces inherits the dimensionality of the chosen model.
+
+Example capability entry:
+
+```json
+{
+  "name": "ema0.1",
+  "model": "Qwen/Qwen3-Embedding-0.6B",
+  "dims": 1024,
+  "params": {
+    "alpha": {
+      "like": 0.05,
+      "repost": 0.075,
+      "reply": 0.15,
+      "bookmark": 0.10
+    }
+  }
+}
+```
+
+## Parameters
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `alpha` | Object | Yes | Per-event-kind EMA learning rates. Required keys: `like`, `repost`, `reply`, `bookmark`. Each value MUST be a number in `[0, 1]` |
+
+`alpha[k]` is the weight given to a new event of kind `k` in the EMA update; `1 − alpha[k]` is the weight retained from prior state. Setting `alpha[k] = 0` causes events of that kind to have no effect on the user vector. Setting `alpha[k] = 1` causes events of that kind to replace prior state entirely.
+
+The provider advertises `alpha` in the capability entry's `params` object. Consumers MUST use exactly the values declared by the provider. Two providers advertising `ema0.1` with different `alpha` values will produce different vectors from the same behavior.
+
+## Encoder
+
+The consumer encodes each engaged post into a unit vector using the model declared in the capability entry. The text fed to the model is, in order, whatever of the following is present: author display name and handle, content warning, post title, post summary, post body, image alt text, hashtags. Fields that are absent are skipped. The exact template used by the reference implementation is at [`fediway/feeds/workers/orbit/templates/embedding.j2`](https://github.com/fediway/feeds/blob/main/workers/orbit/templates/embedding.j2).
+
+The model's output is L2-normalized before aggregation.
+
+### Quantization
+
+Consumers MAY run quantized variants of the declared model (GGUF, AWQ, GPTQ, etc.) for efficient CPU inference. The model identifier in the capability refers to the base model; the quantization is a deployment choice on the consumer side. Quantized inference produces vectors that differ from full precision in low-order bits but remain semantically equivalent for similarity ranking.
+
+### Example
+
+A post with display name "Jane Doe", handle `jane@mastodon.social`, content warning "politics", body "Hello world", image alt texts "A sunset" and "A mountain", and tags "photography" and "nature" renders to:
+
+```
+Jane Doe (@jane@mastodon.social)
+
+[CW: politics]
+
+Hello world
+
+[Image: A sunset]
+
+[Image: A mountain]
+
+#photography #nature
+```
+
+Sections are separated by a single blank line; absent fields are skipped along with their separator. The handle is prefixed with `@`; alt texts are wrapped in `[Image: ...]`; tags are prefixed with `#` and joined by single spaces. Leading and trailing whitespace are trimmed from the final string.
+
+## Aggregation
+
+For each engagement event in chronological order:
+
+```
+new = normalize(α[k] · post_embedding + (1 − α[k]) · current)
+```
+
+where `current` is the user's vector before the event, `post_embedding` is the unit-normalized post embedding, `k` is the event kind, and `α[k]` is the value of `params.alpha[k]`. The result is L2-normalized after every step. The user vector sent in the request is the value of `current` after applying all events.
+
+## Cold start
+
+A user with no prior engagement starts at the zero vector. Consumers SHOULD omit `embedding` in this state when the capability declares `embedding.required: false`. Behavior under `embedding.required: true` for cold-start users is not defined by `ema0.1` and is a candidate for a future revision.
+
+## Negative signals
+
+`ema0.1` does not aggregate hides, mutes, or similar negative signals into the user vector. These are out of scope for this method. A future method (`ema0.2` or sibling) may incorporate them.
+
+## Rotation and perturbation
+
+The wire spec recommends consumers rotate or perturb vectors periodically (see [Queries: Privacy](../../v0.1/queries.md#privacy)). For `ema0.1`, the recommended recipe is re-derivation from a fresh time window: drop the persisted `current` and rebuild the vector from engagements within the last N days, with N chosen by the consumer. Gaussian noise on the final vector (renormalized to unit length) is an acceptable alternative; the noise scale is consumer-determined.
+
+## Reference implementations
+
+- Provider (post encoding): [`fediway/feeds/workers/orbit`](https://github.com/fediway/feeds/tree/main/workers/orbit)
+- Consumer (user vector aggregation): [`fediway/fediway/workers/orbit`](https://github.com/fediway/fediway/tree/main/workers/orbit)

--- a/v0.1/discovery.md
+++ b/v0.1/discovery.md
@@ -74,8 +74,20 @@ When `lookups` is present, lookup and relationship endpoints are also available.
       "multiValue": ["language"],
       "embedding": {
         "required": true,
-        "models": [
-          { "name": "qwen3_256d", "dims": 256 }
+        "methods": [
+          {
+            "name": "ema0.1",
+            "model": "Qwen/Qwen3-Embedding-0.6B",
+            "dims": 1024,
+            "params": {
+              "alpha": {
+                "like": 0.05,
+                "repost": 0.075,
+                "reply": 0.15,
+                "bookmark": 0.10
+              }
+            }
+          }
         ]
       }
     },
@@ -125,15 +137,19 @@ When `lookups` is present, lookup and relationship endpoints are also available.
 
 Capabilities MAY include an `embedding` field to advertise support for embedding-based ranking. When present, the algorithm accepts an interest vector as a query signal (see [Queries: Embedding](queries.md#embedding)). When absent, the algorithm does not accept embeddings.
 
-The `embedding` object tells consumers which models the provider accepts, so they can compute a compatible vector before querying.
+The capability defines what embeddings the provider accepts. Each entry names a method and, when the method needs one, a model. The method fixes how per-event embeddings are aggregated into the user vector; the model (when present) fixes the embedding space. Methods MAY require additional parameters; these are advertised in `params` and applied by the consumer when computing the vector.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `embedding.required` | Boolean | Yes | Whether the embedding MUST be provided. If `true`, requests without an embedding return `422` |
-| `embedding.models` | Array | Yes | Accepted embedding models. At least one |
-| `embedding.models[].name` | String | Yes | Model identifier. Consumers use this to select and label their vectors |
-| `embedding.models[].dims` | Integer | Yes | Expected vector dimensionality. Vectors with a different length are rejected |
+| `embedding.methods` | Array | Yes | Accepted methods. At least one |
+| `embedding.methods[].name` | String | Yes | Method identifier (e.g. `ema0.1`). See [embedding methods](../guidelines/embeddings/) for documented methods |
+| `embedding.methods[].model` | String | Conditional | Model identifier. Required when the method depends on an external embedding model; omitted when the method is self-contained |
+| `embedding.methods[].dims` | Integer | Yes | Expected vector dimensionality. Vectors with a different length are rejected |
+| `embedding.methods[].params` | Object | Conditional | Method-defined parameters required to reproduce the vector. Required keys, types, and value ranges are defined by the method. Omitted when the method takes no parameters |
+
+Consumers MUST follow the method declared by the provider, including any `params` values. Two consumers querying the same provider with the same `(name, model, params)` triple MUST produce the same vector from the same user behavior. Running a different aggregation, a different model, or different parameter values breaks comparability across consumers.
 
 A capability with `embedding.required: true` cannot return meaningful results without a vector; the embedding is the primary query signal. A capability with `embedding.required: false` uses the embedding as an optional ranking boost alongside other signals.
 
-When a provider supports multiple models, consumers SHOULD prefer the first model in the array. Providers SHOULD order models by preference (recommended first).
+When a provider lists multiple methods, consumers SHOULD prefer the first entry in the array. Providers SHOULD order entries by preference (recommended first).

--- a/v0.1/queries.md
+++ b/v0.1/queries.md
@@ -80,20 +80,22 @@ The embedding is a top-level request field, not a filter or parameter. It carrie
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `embedding.vector` | Float[] | Yes | Interest vector. MUST be unit-normalized (L2 norm ≈ 1.0) |
-| `embedding.model` | String | Yes | Model identifier. MUST match a `name` from the capability's `embedding.models` array |
+| `embedding.method` | String | Yes | Method identifier. MUST match a `name` from the capability's `embedding.methods` array |
+| `embedding.model` | String | Conditional | Model identifier. Required when the matched method entry declares a `model`; MUST be omitted otherwise. When present, MUST match the entry's `model` |
 
 ### Validation
 
 Providers MUST validate the embedding and return `422 invalid_params` with a descriptive `param` and `message` if validation fails:
 
 - **Missing required embedding**: if the capability declares `embedding.required: true` and the request omits `embedding`, return `422` with `param: "embedding"`.
-- **Unknown model**: if `embedding.model` does not match any model in the capability's `embedding.models` array, return `422` with `param: "embedding.model"`. The error message SHOULD list the supported model names.
-- **Wrong dimensions**: if `embedding.vector` length does not equal the model's `dims`, return `422` with `param: "embedding.vector"`. The error message SHOULD include the actual and expected dimensions.
+- **Unknown method**: if `embedding.method` does not match any `name` in the capability's `embedding.methods` array, return `422` with `param: "embedding.method"`. The error message SHOULD list the supported method identifiers.
+- **Model mismatch**: if the matched method entry declares a `model` and the request's `embedding.model` is missing or does not match, return `422` with `param: "embedding.model"`. If the matched method entry has no `model` and the request includes `embedding.model`, return `422` with `param: "embedding.model"`.
+- **Wrong dimensions**: if `embedding.vector` length does not equal the matched entry's `dims`, return `422` with `param: "embedding.vector"`. The error message SHOULD include the actual and expected dimensions.
 - **Zero vector**: if all elements of `embedding.vector` are zero, return `422` with `param: "embedding.vector"`. A zero vector has no direction and cannot produce meaningful similarity rankings.
 
 ### Privacy
 
-The embedding is an aggregated interest signal, not browsing history. It does not contain identifiers for individual posts or authors. Consumers compute the vector locally from user behavior and send only the resulting vector. Providers cannot reconstruct which specific content a user interacted with from the vector alone.
+The embedding is an aggregated interest signal, not browsing history. It does not contain identifiers for individual posts or authors. Consumers compute the vector locally by following the method declared in the capability (see [embedding methods](../guidelines/embeddings/)) and send only the resulting vector. Providers cannot reconstruct which specific content a user interacted with from the vector alone.
 
 Consumers SHOULD rotate or perturb vectors periodically to limit long-term profiling. Providers MUST NOT store embeddings beyond the lifetime of the request.
 
@@ -111,8 +113,9 @@ Authorization: Bearer cf_live_abc123xyz
 ```json
 {
   "embedding": {
-    "vector": [0.023, -0.041, 0.019, "... 256 floats total ..."],
-    "model": "qwen3_256d"
+    "vector": [0.023, -0.041, 0.019, "... 1024 floats total ..."],
+    "method": "ema0.1",
+    "model": "Qwen/Qwen3-Embedding-0.6B"
   },
   "filters": {
     "language": ["en", "de"]


### PR DESCRIPTION
Address embedding-computation feedback (#3):

- Discovery: rename `embedding.models` → `embedding.methods`. Each entry is `{ name, model?, dims, params? }`. The `name` identifies the method (e.g. `ema0.1`); `model` is conditional on whether the method depends on an external embedding model; `params` carries method-defined tunables required to reproduce the vector.
- Queries: split the prior `embedding.model` field into `embedding.method` (always required) and `embedding.model` (required only when the matched method entry declares one).
- Two consumers querying the same provider with the same `(name, model, params)` triple MUST produce the same vector from the same user behavior.
- Add `guidelines/embeddings/` directory documenting methods. The wire spec stays narrow; per-method docs cover encoder, aggregation rule, parameters, cold start, negative signals, rotation, and perturbation.
- First method entry: `ema0.1` (per-event-kind EMA over per-post content embeddings; `params.alpha` is an object keyed by engagement kind). Reference implementations linked.
- Update discovery and queries copy and examples.
- Add a row to the top-level README spec table.

Reference implementation update (orbit code: per-kind `α` in place of scalar `α` + fixed weight table, symmetric convex combination in place of asymmetric decay) is tracked separately and will land before any provider advertises `ema0.1` in production.

Closes #3