### PR TITLE
Add mediaType filter

### DIFF
--- a/v0.1/discovery.md
+++ b/v0.1/discovery.md
@@ -55,8 +55,8 @@ When `lookups` is present, lookup and relationship endpoints are also available.
       "algorithm": "trending",
       "description": "Trending content by engagement velocity",
       "params": ["window"],
-      "filters": ["language", "protocol", "tag"],
-      "multiValue": ["language", "tag"]
+      "filters": ["language", "protocol", "tag", "mediaType"],
+      "multiValue": ["language", "tag", "mediaType"]
     },
     {
       "resource": "posts",

--- a/v0.1/queries.md
+++ b/v0.1/queries.md
@@ -63,9 +63,26 @@ Providers and consumers SHOULD use the following well-known filter names where a
 | `language` | String / String[] | ISO 639-1 language codes |
 | `contentType` | String / String[] | `post`, `article`, `reply` |
 | `hasMedia` | Boolean | Filter to posts with media attachments |
+| `mediaType` | String / String[] | `image`, `loop`, `landscapeVideo`, `verticalVideo`, `audio` (see [Media types](#media-types)) |
 | `protocol` | String / String[] | `activitypub`, `atproto`, `nostr` |
 | `tag` | String / String[] | Hashtag names (lowercase, no `#` prefix). Returns content matching **any** of the provided tags (OR semantics). Accepts multiple values only if `"tag"` is listed in the capability's `multiValue` array (see [Discovery](discovery.md)); otherwise a single value only |
 | `link` | String | URL of a link. Returns content that references this link |
+
+### Media types
+
+A `mediaType` value identifies a post by the consumption surface it is rendered in, not by file format. The aim is to let consumers select posts that fit a specific consumption surface. A value earns inclusion only when its consumption surface requires a distinct renderer rather than a parameter on an existing one. Future versions may introduce additional values under the same criterion.
+
+| Value | Definition |
+|-------|------------|
+| `image` | Still image, single or gallery. Any aspect ratio |
+| `loop` | Short animation that auto-plays muted and loops. File format is irrelevant: animated GIFs served as MP4, Mastodon `gifv`, and animated stickers all classify as `loop` |
+| `landscapeVideo` | Video wider than tall, finite duration, audio-on by default |
+| `verticalVideo` | Video taller than wide, finite duration, audio-on by default |
+| `audio` | Sound-only content such as podcasts or music |
+
+`mediaType` is a post-level classification derived from media metadata. It is distinct from the per-attachment `type` on the [Media Object](posts.md#media-object), which classifies each attachment's file kind (`image`, `video`, `audio`) rather than the post's consumption surface.
+
+A post with mixed attachments classifies by its dominant attachment. Square video and other edge orientation cases are provider-defined. Posts without media match no `mediaType` value.
 
 Providers MAY define additional custom filters beyond this list. Custom filters MUST be declared in the capability's discovery entry.
 


### PR DESCRIPTION
CommonFeed is meant to support different kinds of products on top of the same protocol: image feeds, short-vertical-video feeds, podcast feeds, long-form video feeds. Without a way to filter by media kind, every consumer receives a mixed bag and has to discard on the client.

This PR adds a `mediaType` filter to the well-known set:

- New filter `mediaType` with values `image`, `loop`, `landscapeVideo`, `verticalVideo`, `audio`. String or String[] when the capability lists `mediaType` in `multiValue`.
- Values describe the consumption surface a post renders in, not file format. Pixelfed-style clients query `image`. Loops-style clients query `verticalVideo`. Long-form video clients query `landscapeVideo`. Podcast clients query `audio`.
- Orientation split for video because vertical-feed and landscape-feed players are structurally different products. No orientation split for image or audio: the same renderer handles every aspect ratio. A media-type value earns its place only when the consumption surface is fundamentally different.
- `loop` is defined by consumption mode, not file format. Short, muted-by-default, auto-looping clips. Covers animated GIFs served as MP4, Mastodon `gifv`, and animated stickers. Distinguished from `landscapeVideo` and `verticalVideo` by its silent-loop mode.
- No numeric thresholds (duration, exact aspect ratio). Orientation is stable metadata across all three protocols and correlates with the short-form-feed genre in practice. Duration cutoffs are arbitrary and divisive.
- `hasMedia` stays. Presence/absence is distinct from kind, and `hasMedia: false` (text-only) cannot be expressed as a `mediaType` value set.
- Filter `mediaType` is post-level and derived. The per-attachment `type` on the Media Object stays at `image|video|audio` and classifies file kind. A note in `queries.md` makes the distinction explicit.
- Discovery example for `posts/trending` adds `mediaType` to `filters` and `multiValue`.

Example capability:

```json
{
  "resource": "posts",
  "algorithm": "trending",
  "filters": ["language", "mediaType"],
  "multiValue": ["language", "mediaType"]
}
```

A Loops-style client requests short vertical video:

```bash
curl -X POST https://provider.example/api/v1/posts/trending \
  -H "Authorization: Bearer cf_live_abc123xyz" \
  -H "Content-Type: application/json" \
  -d '{"filters": {"mediaType": "verticalVideo"}}'
```